### PR TITLE
Fix duplicate OWNS-relation between user `be5d2aa7-5ff8-4ca2-ba03-20a…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Fixed
+- Fix duplicate OWNS-relation between user `be5d2aa7-5ff8-4ca2-ba03-20a9c10ffdb1` and token
+  `ae26e994-7511-4269-929f-01d075cc7c36` within scenario `security.multipleGroups.immediateNodeOwnership`.
 
 ## 0.0.21 - 2023-12-16
 ### Added

--- a/relation/command/token/revoke/group/owns-token6.json
+++ b/relation/command/token/revoke/group/owns-token6.json
@@ -1,9 +1,0 @@
-{
-  "type": "OWNS",
-  "id": "dd949865-cf4a-4a73-81ee-eb011d55facd",
-  "start": "be5d2aa7-5ff8-4ca2-ba03-20a9c10ffdb1",
-  "end": "ae26e994-7511-4269-929f-01d075cc7c36",
-  "data": {
-    "scenario": "command.token.revoke.group"
-  }
-}


### PR DESCRIPTION
…9c10ffdb1` and token

`ae26e994-7511-4269-929f-01d075cc7c36` within scenario `security.multipleGroups.immediateNodeOwnership`.